### PR TITLE
Set flag local to true after mqtt

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -98,6 +98,7 @@ export default {
             device.reqFlag = false;
           }
         } else this.showSnackBar('error', 'Request Failed');
+        this.isLocal = true;
       }
     }
   },


### PR DESCRIPTION
If mqtt is used as fallback, we get double values, from azure and mqtt
so set islocal to true