### PR TITLE
Don't skip refresh values

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -17,8 +17,7 @@ export default new Router({
     {
       path: '/home',
       name: 'home',
-      component: Home,
-      props: { fromLogin: true }
+      component: Home
     }
   ]
 });

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -104,13 +104,7 @@ export default {
     }
   }),
   created() {
-    if (!this.fromLogin) this.refreshValues();
-  },
-  props: {
-    fromLogin: {
-      type: Boolean,
-      default: false
-    }
+    this.refreshValues();
   },
   components: {
     Spinner

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -60,7 +60,7 @@ export default {
   created() {
     if (localStorage.getItem('username')) {
       console.log('we have username');
-      this.$router.replace('/home?fromLogin=true');
+      this.$router.replace('/home');
     }
   }
 };


### PR DESCRIPTION
We used check that if we have username we don't load devices.
But were skipping out on additional data from server.
App replaces login by home on history stack so that user will exit if
we presses back